### PR TITLE
Release 2.0.2

### DIFF
--- a/apache2.2/conf/extra/includes/host.conf
+++ b/apache2.2/conf/extra/includes/host.conf
@@ -19,5 +19,10 @@ CustomLog /proc/self/fd/1 combined
 	</IfDefine>
 </Directory>
 
-# Proxy php requests to fcgi
+# PHP request handling via mod_proxy and mod_proxy_fcgi
+# Using ProxyPassMatch here, since the backported version of the mod_proxy_fcgi module (ceph/mod-proxy-fcgi)
+# does not support using "SetHandler" statements. As a result, there may be opssible caveats:
+# https://ma.ttias.be/apache-2-4-proxypass-for-php-taking-precedence-over-filesfilesmatch-in-htaccess
+
+# Proxy php requests to the fcgi endpoint
 ProxyPassMatch "^/(.*\.php(/.*)?)$" "fcgi://${APACHE_FCGI_HOST_PORT}/${APACHE_DOCUMENTROOT}/$1"

--- a/apache2.4/conf/extra/includes/host.conf
+++ b/apache2.4/conf/extra/includes/host.conf
@@ -21,5 +21,15 @@ CustomLog /proc/self/fd/1 combined
 	</IfDefine>
 </Directory>
 
-# Proxy php requests to fcgi
-ProxyPassMatch "^/(.*\.php(/.*)?)$" "fcgi://${APACHE_FCGI_HOST_PORT}/${APACHE_DOCUMENTROOT}/$1"
+# PHP request handling via mod_proxy and mod_proxy_fcgi
+<FilesMatch "\.php$">
+	# Let Apache handle the request is a file is missing
+	<If "-f %{REQUEST_FILENAME}">
+		# Proxy php requests to the fcgi endpoint
+		SetHandler "proxy:fcgi://${APACHE_FCGI_HOST_PORT}"
+	</If>
+</FilesMatch>
+# Additional proxy settings
+<Proxy "fcgi://${APACHE_FCGI_HOST_PORT}">
+	ProxySet connectiontimeout=5 timeout=600
+</Proxy>


### PR DESCRIPTION
- Use of SetHandler vs ProxyPassMatch
  - SetHandler is a better option, but only works with apache 2.4.
  - With apache 2.2 we have to use ProxyPassMatch as the only option with the backported mod_proxy_fcgi.