### PR TITLE
enable rewrite_module in apache

### DIFF
--- a/apache2.2/Dockerfile
+++ b/apache2.2/Dockerfile
@@ -34,6 +34,7 @@ RUN set -x \
 	&& sed -i '/^LoadModule proxy_module /a LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so' /usr/local/apache2/conf/httpd.conf \
 	&& sed -i '/^#.* proxy_connect_module /s/^#//' /usr/local/apache2/conf/httpd.conf \
 	&& sed -i '/^#.* ssl_module /s/^#//' /usr/local/apache2/conf/httpd.conf \
+	&& sed -i '/^#.* rewrite_module /s/^#//' /usr/local/apache2/conf/httpd.conf \
 	# Enable extra config files
 	&& sed -i '/^#.* conf\/extra\/httpd-vhosts.conf/s/^#//' /usr/local/apache2/conf/httpd.conf \
 	&& sed -i '/^#.* conf\/extra\/httpd-ssl.conf/s/^#//' /usr/local/apache2/conf/httpd.conf

--- a/apache2.4/Dockerfile
+++ b/apache2.4/Dockerfile
@@ -13,6 +13,7 @@ RUN set -x \
 	&& sed -i '/^#.* proxy_connect_module /s/^#//' /usr/local/apache2/conf/httpd.conf \
 	&& sed -i '/^#.* ssl_module /s/^#//' /usr/local/apache2/conf/httpd.conf \
 	&& sed -i '/^#.* socache_shmcb_module /s/^#//' /usr/local/apache2/conf/httpd.conf \
+	&& sed -i '/^#.* rewrite_module /s/^#//' /usr/local/apache2/conf/httpd.conf \
 	# Enable extra config files
 	&& sed -i '/^#.* conf\/extra\/httpd-vhosts.conf/s/^#//' /usr/local/apache2/conf/httpd.conf \
 	&& sed -i '/^#.* conf\/extra\/httpd-ssl.conf/s/^#//' /usr/local/apache2/conf/httpd.conf


### PR DESCRIPTION
Upgraded to Docksal version  1.4 and using the new docksal/web:2.0-apache2.4 image.
Problem was that I couldn't login in my website under drupal7.docksal/user, but drupal7.docksal/?q=user worked.

Reason: the rewrite_module for apache was not enabled, after enabling it, I could login under /user.