### PR TITLE
Release 2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 language: generic
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: required
+
+language: generic
+
+services:
+  - docker
+
+env:
+  matrix:
+    - VERSION=apache2.2
+    - VERSION=apache2.4
+
+install:
+  - curl -fsSL get.docksal.io | sh
+  - fin version
+  - fin sysinfo
+
+script:
+  - cd ${VERSION}
+  - make && make test
+
+after_failure:
+  - make logs

--- a/README.md
+++ b/README.md
@@ -9,9 +9,15 @@ This image(s) is part of the [Docksal](http://docksal.io) image library.
 
 ## Features
 
-- SSL enabled (self-signed cer)
-- HTTP Basic Authentication
+- SSL enabled (self-signed cert)
 - PHP handling via FastCGI (`mod_proxy_fcgi`) (both 2.2 and 2.4)
+- HTTP Basic Authentication
+- Support for configuration overrides
+
+## Document root
+
+Apache `DocumentRoot` for the default virtual host can be set via `APACHE_DOCUMENTROOT`environment variable 
+(defaults to `/var/www/docroot`). 
 
 ## FastCGI server endpoint
 
@@ -30,4 +36,25 @@ Example with Docker Compose
     - APACHE_BASIC_AUTH_USER=user
     - APACHE_BASIC_AUTH_PASS=password
   ...
+```
+
+## Configuration overrides
+
+Configuration overrides can be added to a Docksal project codebase.
+
+Use `.docksal/etc/apache/httpd-vhost-overrides.conf` to override the default virtual host configuration:
+
+```apacheconfig
+DirectoryIndex index2.html
+```
+
+Use `.docksal/etc/apache/httpd-vhosts.conf` to define additional virtual hosts:
+
+```apacheconfig
+<VirtualHost *:80>
+	ServerName docs.test.docksal
+
+	ProxyPass / http://docs.docksal.io/
+	ProxyPassReverse / http://docs.docksal.io/
+</VirtualHost>
 ```

--- a/apache2.2/.dockerignore
+++ b/apache2.2/.dockerignore
@@ -1,0 +1,2 @@
+.dockerignore
+Makefile

--- a/apache2.2/Dockerfile
+++ b/apache2.2/Dockerfile
@@ -42,6 +42,8 @@ RUN set -x \
 	&& sed -i '/^#.* rewrite_module /s/^#//' /usr/local/apache2/conf/httpd.conf \
 	# Enable extra config files
 	&& sed -i '/^#.* conf\/extra\/httpd-vhosts.conf/s/^#//' /usr/local/apache2/conf/httpd.conf \
+	# Used for runtime config overrides
+	&& mkdir -p /usr/local/apache2/conf/custom \
 	# Link out custom docroot location to the default htdocs folder by default
 	&& mkdir -p /var/www \
 	&& ln -s /usr/local/apache2/htdocs $APACHE_DOCUMENTROOT

--- a/apache2.2/Dockerfile
+++ b/apache2.2/Dockerfile
@@ -24,9 +24,14 @@ RUN set -x \
 
 # Generate a self-signed cert
 RUN apk add --no-cache openssl \
-	&& openssl req -batch -x509 -newkey rsa:4086 -days 3650 -nodes -sha256 \
+	&& openssl req -batch -x509 -newkey rsa:4096 -days 3650 -nodes -sha256 \
 		-keyout /usr/local/apache2/conf/server.key -out /usr/local/apache2/conf/server.crt \
 	&& apk del openssl
+
+# Configure Apache environment variables
+ENV \
+	APACHE_DOCUMENTROOT=/var/www/docroot \
+	APACHE_FCGI_HOST_PORT="cli:9000"
 
 RUN set -x \
 	# Enabled extra modules
@@ -37,16 +42,12 @@ RUN set -x \
 	&& sed -i '/^#.* rewrite_module /s/^#//' /usr/local/apache2/conf/httpd.conf \
 	# Enable extra config files
 	&& sed -i '/^#.* conf\/extra\/httpd-vhosts.conf/s/^#//' /usr/local/apache2/conf/httpd.conf \
-	&& sed -i '/^#.* conf\/extra\/httpd-ssl.conf/s/^#//' /usr/local/apache2/conf/httpd.conf
+	# Link out custom docroot location to the default htdocs folder by default
+	&& mkdir -p /var/www \
+	&& ln -s /usr/local/apache2/htdocs $APACHE_DOCUMENTROOT
 
 COPY httpd-foreground /usr/local/bin/
 COPY conf /usr/local/apache2/conf
-
-# Configure Apache environment variables
-ENV \
-	APACHE_SERVERADMIN=webmaster@localhost \
-	APACHE_DOCUMENTROOT=/var/www/docroot \
-	APACHE_FCGI_HOST_PORT="cli:9000"
 
 WORKDIR /var/www
 

--- a/apache2.2/Makefile
+++ b/apache2.2/Makefile
@@ -1,0 +1,40 @@
+-include env_make
+
+VERSION ?= apache2.2
+
+REPO = docksal/web
+NAME = docksal-apache-2.2
+
+.PHONY: build test push shell run start stop logs clean release
+
+build:
+	fin docker build -t $(REPO):$(VERSION) .
+
+test:
+	IMAGE=$(REPO):$(VERSION) NAME=$(NAME) ../tests/test.bats
+
+push:
+	fin docker push $(REPO):$(VERSION)
+
+shell:
+	fin docker run --rm --name $(NAME) -it $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(VERSION) /bin/bash
+
+run:
+	fin docker run --rm --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(VERSION)
+
+start:
+	fin docker run -d --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(VERSION)
+
+stop:
+	fin docker stop $(NAME)
+
+logs:
+	fin docker logs $(NAME)
+
+clean:
+	fin docker rm -f $(NAME)
+
+release: build
+	make push -e VERSION=$(VERSION)
+
+default: build

--- a/apache2.2/conf/extra/httpd-vhosts.conf
+++ b/apache2.2/conf/extra/httpd-vhosts.conf
@@ -1,15 +1,30 @@
 ServerName ${APACHE_SERVERNAME}
-ServerAdmin ${APACHE_SERVERADMIN}
 
-# HTTP
-<VirtualHost _default_:80>
+# Use name based virtual hosts
+# The first defined name base virtual host is the default one
+NameVirtualHost *:80
+NameVirtualHost *:443
+
+# HTTP (default virtual host)
+<VirtualHost *:80>
 	Include conf/extra/includes/host.conf
 </VirtualHost>
 
-# HTTPS
+# HTTPS (default virtual host)
 <IfModule mod_ssl.c>
-	<VirtualHost _default_:443>
+	Listen 443
+	# Restrict mod_ssl to use only TLSv1.2 ciphers
+	SSLCipherSuite HIGH:MEDIUM:!SSLv3:!kRSA
+	SSLProxyCipherSuite HIGH:MEDIUM:!SSLv3:!kRSA
+	SSLHonorCipherOrder on
+	# Only allow the TLSv1.2 protocol
+	SSLProtocol TLSv1.2
+	SSLProxyProtocol TLSv1.2
+	# Other SSL settings
+	SSLSessionCache        "shmcb:/usr/local/apache2/logs/ssl_scache(512000)"
+	SSLSessionCacheTimeout  300
 
+	<VirtualHost *:443>
 		Include conf/extra/includes/host.conf
 
 		SSLEngine on

--- a/apache2.2/conf/extra/httpd-vhosts.conf
+++ b/apache2.2/conf/extra/httpd-vhosts.conf
@@ -7,6 +7,10 @@ NameVirtualHost *:443
 
 # HTTP (default virtual host)
 <VirtualHost *:80>
+	# Allow virtual-host config overrides (overrides go first, as Apache picks the first instance of a directive)
+	# Using a glob pattern in the file name to avoid creating an empty config by default
+	Include conf/custom/httpd-vhost-overrides.con[f]
+	# Standard virtual-host configuration
 	Include conf/extra/includes/host.conf
 </VirtualHost>
 
@@ -25,6 +29,10 @@ NameVirtualHost *:443
 	SSLSessionCacheTimeout  300
 
 	<VirtualHost *:443>
+		# Allow virtual-host config overrides (overrides go first, as Apache picks the first instance of a directive)
+		# Using a glob pattern in the file name to avoid creating an empty config by default
+		Include conf/custom/httpd-vhost-overrides.con[f]
+		# Standard virtual-host configuration
 		Include conf/extra/includes/host.conf
 
 		SSLEngine on
@@ -37,3 +45,7 @@ NameVirtualHost *:443
 
 	</VirtualHost>
 </IfModule>
+
+# Allow configuring additional virtual hosts
+# Using a glob pattern in the file name to avoid creating an empty config by default
+Include conf/custom/httpd-vhosts.con[f]

--- a/apache2.2/conf/extra/includes/host.conf
+++ b/apache2.2/conf/extra/includes/host.conf
@@ -2,12 +2,8 @@ DocumentRoot ${APACHE_DOCUMENTROOT}
 # Make sure index.php is loaded by default
 # E.g. WP does not ship with a default .htacess and a rule for DirectoryIndex.
 # It's best to set it here as that's the standard for any PHP app anyway.
-# Priority order: folder level index.php, folder level index.html
-DirectoryIndex index.php index.html
-
-# Route logs to STDOUT (/proc/self/fd/1) and STDERR (/proc/self/fd/2)
-ErrorLog /proc/self/fd/2
-CustomLog /proc/self/fd/1 combined
+# Priority order: folder level index.html, folder level index.php
+DirectoryIndex index.html index.php
 
 <Directory "${APACHE_DOCUMENTROOT}">
 	Options FollowSymLinks

--- a/apache2.2/httpd-foreground
+++ b/apache2.2/httpd-foreground
@@ -9,6 +9,19 @@ echo "Configuring Apache2 environment variables..."
 # Set ServerName of created container
 export APACHE_SERVERNAME="${APACHE_SERVERNAME:-$(cat /etc/hostname)}"
 
+# Support for configuration overrides
+include_conf ()
+{
+	file=$1
+
+	if [[ -f "$file" ]]; then
+		echo "Including configuration overrides from $file"
+		cp "$file" /usr/local/apache2/conf/custom
+	fi
+}
+include_conf "/var/www/.docksal/etc/apache/httpd-vhost-overrides.conf"
+include_conf "/var/www/.docksal/etc/apache/httpd-vhosts.conf"
+
 # Run in foreground
 args="-DFOREGROUND"
 

--- a/apache2.2/httpd-foreground
+++ b/apache2.2/httpd-foreground
@@ -9,11 +9,14 @@ echo "Configuring Apache2 environment variables..."
 # Set ServerName of created container
 export APACHE_SERVERNAME="${APACHE_SERVERNAME:-$(cat /etc/hostname)}"
 
+# Run in foreground
+args="-DFOREGROUND"
+
 # Basic HTTP Authentication
 if [[ "$APACHE_BASIC_AUTH_USER" != "" ]] && [[ "$APACHE_BASIC_AUTH_PASS" != "" ]]; then
 	echo "Enabling Basic HTTP Authentication [$APACHE_BASIC_AUTH_USER:$APACHE_BASIC_AUTH_PASS]"
 	htpasswd -cb /usr/local/apache2/htpasswd "$APACHE_BASIC_AUTH_USER" "$APACHE_BASIC_AUTH_PASS"
-	exec httpd -DFOREGROUND -DBasicAuth
-else
-	exec httpd -DFOREGROUND
+	args+=" -DBasicAuth"
 fi
+
+exec httpd ${args}

--- a/apache2.4/.dockerignore
+++ b/apache2.4/.dockerignore
@@ -1,0 +1,2 @@
+.dockerignore
+Makefile

--- a/apache2.4/Dockerfile
+++ b/apache2.4/Dockerfile
@@ -14,6 +14,7 @@ ENV \
 RUN set -x \
 	# Enabled extra modules
 	&& sed -i '/^#.* proxy_module /s/^#//' /usr/local/apache2/conf/httpd.conf \
+	&& sed -i '/^#.* proxy_http_module /s/^#//' /usr/local/apache2/conf/httpd.conf \
 	&& sed -i '/^#.* proxy_fcgi_module /s/^#//' /usr/local/apache2/conf/httpd.conf \
 	&& sed -i '/^#.* proxy_connect_module /s/^#//' /usr/local/apache2/conf/httpd.conf \
 	&& sed -i '/^#.* ssl_module /s/^#//' /usr/local/apache2/conf/httpd.conf \

--- a/apache2.4/Dockerfile
+++ b/apache2.4/Dockerfile
@@ -21,6 +21,8 @@ RUN set -x \
 	&& sed -i '/^#.* rewrite_module /s/^#//' /usr/local/apache2/conf/httpd.conf \
 	# Enable extra config files
 	&& sed -i '/^#.* conf\/extra\/httpd-vhosts.conf/s/^#//' /usr/local/apache2/conf/httpd.conf \
+	# Used for runtime config overrides
+	&& mkdir -p /usr/local/apache2/conf/custom \
 	# Link out custom docroot location to the default htdocs folder by default
 	&& mkdir -p /var/www \
 	&& ln -s /usr/local/apache2/htdocs $APACHE_DOCUMENTROOT

--- a/apache2.4/Dockerfile
+++ b/apache2.4/Dockerfile
@@ -2,9 +2,14 @@ FROM httpd:2.4-alpine
 
 # Generate a self-signed cert
 RUN apk add --no-cache openssl \
-	&& openssl req -batch -x509 -newkey rsa:4086 -days 3650 -nodes -sha256 \
+	&& openssl req -batch -x509 -newkey rsa:4096 -days 3650 -nodes -sha256 \
 		-keyout /usr/local/apache2/conf/server.key -out /usr/local/apache2/conf/server.crt \
 	&& apk del openssl
+
+# Configure Apache environment variables
+ENV \
+	APACHE_DOCUMENTROOT=/var/www/docroot \
+	APACHE_FCGI_HOST_PORT="cli:9000"
 
 RUN set -x \
 	# Enabled extra modules
@@ -16,16 +21,12 @@ RUN set -x \
 	&& sed -i '/^#.* rewrite_module /s/^#//' /usr/local/apache2/conf/httpd.conf \
 	# Enable extra config files
 	&& sed -i '/^#.* conf\/extra\/httpd-vhosts.conf/s/^#//' /usr/local/apache2/conf/httpd.conf \
-	&& sed -i '/^#.* conf\/extra\/httpd-ssl.conf/s/^#//' /usr/local/apache2/conf/httpd.conf
+	# Link out custom docroot location to the default htdocs folder by default
+	&& mkdir -p /var/www \
+	&& ln -s /usr/local/apache2/htdocs $APACHE_DOCUMENTROOT
 
 COPY httpd-foreground /usr/local/bin/
 COPY conf /usr/local/apache2/conf
-
-# Configure Apache environment variables
-ENV \
-	APACHE_SERVERADMIN=webmaster@localhost \
-	APACHE_DOCUMENTROOT=/var/www/docroot \
-	APACHE_FCGI_HOST_PORT="cli:9000"
 
 WORKDIR /var/www
 

--- a/apache2.4/Makefile
+++ b/apache2.4/Makefile
@@ -1,0 +1,40 @@
+-include env_make
+
+VERSION ?= apache2.4
+
+REPO = docksal/web
+NAME = docksal-apache-2.4
+
+.PHONY: build test push shell run start stop logs clean release
+
+build:
+	fin docker build -t $(REPO):$(VERSION) .
+
+test:
+	IMAGE=$(REPO):$(VERSION) NAME=$(NAME) ../tests/test.bats
+
+push:
+	fin docker push $(REPO):$(VERSION)
+
+shell:
+	fin docker run --rm --name $(NAME) -it $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(VERSION) /bin/bash
+
+run:
+	fin docker run --rm --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(VERSION)
+
+start:
+	fin docker run -d --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(VERSION)
+
+stop:
+	fin docker stop $(NAME)
+
+logs:
+	fin docker logs $(NAME)
+
+clean:
+	fin docker rm -f $(NAME)
+
+release: build
+	make push -e VERSION=$(VERSION)
+
+default: build

--- a/apache2.4/conf/extra/httpd-vhosts.conf
+++ b/apache2.4/conf/extra/httpd-vhosts.conf
@@ -2,6 +2,10 @@ ServerName ${APACHE_SERVERNAME}
 
 # HTTP (default virtual host)
 <VirtualHost *:80>
+	# Allow virtual-host config overrides (overrides go first, as Apache picks the first instance of a directive)
+	# Using a glob pattern in the file name to avoid creating an empty config by default
+	IncludeOptional conf/custom/httpd-vhost-overrides.con[f]
+	# Standard virtual-host configuration
 	Include conf/extra/includes/host.conf
 </VirtualHost>
 
@@ -20,6 +24,10 @@ ServerName ${APACHE_SERVERNAME}
 	SSLSessionCacheTimeout 300
 
 	<VirtualHost *:443>
+		# Allow virtual-host config overrides (overrides go first, as Apache picks the first instance of a directive)
+		# Using a glob pattern in the file name to avoid creating an empty config by default
+		IncludeOptional conf/custom/httpd-vhost-overrides.con[f]
+		# Standard virtual-host configuration
 		Include conf/extra/includes/host.conf
 
 		SSLEngine on
@@ -32,3 +40,7 @@ ServerName ${APACHE_SERVERNAME}
 
 	</VirtualHost>
 </IfModule>
+
+# Allow configuring additional virtual hosts
+# Using a glob pattern in the file name to avoid creating an empty config by default
+IncludeOptional conf/custom/httpd-vhosts.con[f]

--- a/apache2.4/conf/extra/httpd-vhosts.conf
+++ b/apache2.4/conf/extra/httpd-vhosts.conf
@@ -1,15 +1,25 @@
 ServerName ${APACHE_SERVERNAME}
-ServerAdmin ${APACHE_SERVERADMIN}
 
-# HTTP
-<VirtualHost _default_:80>
+# HTTP (default virtual host)
+<VirtualHost *:80>
 	Include conf/extra/includes/host.conf
 </VirtualHost>
 
-# HTTPS
+# HTTPS (default virtual host)
 <IfModule mod_ssl.c>
-	<VirtualHost _default_:443>
+	Listen 443
+	# Restrict mod_ssl to use only TLSv1.2 ciphers
+	SSLCipherSuite HIGH:MEDIUM:!SSLv3:!kRSA
+	SSLProxyCipherSuite HIGH:MEDIUM:!SSLv3:!kRSA
+	SSLHonorCipherOrder on
+	# Only allow the TLSv1.2 protocol
+	SSLProtocol TLSv1.2
+	SSLProxyProtocol TLSv1.2
+	# Other SSL settings
+	SSLSessionCache "shmcb:/usr/local/apache2/logs/ssl_scache(512000)"
+	SSLSessionCacheTimeout 300
 
+	<VirtualHost *:443>
 		Include conf/extra/includes/host.conf
 
 		SSLEngine on

--- a/apache2.4/conf/extra/includes/host.conf
+++ b/apache2.4/conf/extra/includes/host.conf
@@ -2,12 +2,8 @@ DocumentRoot ${APACHE_DOCUMENTROOT}
 # Make sure index.php is loaded by default
 # E.g. WP does not ship with a default .htacess and a rule for DirectoryIndex.
 # It's best to set it here as that's the standard for any PHP app anyway.
-# Priority order: folder level index.php, folder level index.html
-DirectoryIndex index.php index.html
-
-# Route logs to STDOUT (/proc/self/fd/1) and STDERR (/proc/self/fd/2)
-ErrorLog /proc/self/fd/2
-CustomLog /proc/self/fd/1 combined
+# Priority order: folder level index.html, folder level index.php
+DirectoryIndex index.html index.php
 
 <Directory "${APACHE_DOCUMENTROOT}">
 	Options FollowSymLinks

--- a/apache2.4/httpd-foreground
+++ b/apache2.4/httpd-foreground
@@ -9,6 +9,19 @@ echo "Configuring Apache2 environment variables..."
 # Set ServerName of created container
 export APACHE_SERVERNAME="${APACHE_SERVERNAME:-$(cat /etc/hostname)}"
 
+# Support for configuration overrides
+include_conf ()
+{
+	file=$1
+
+	if [[ -f "$file" ]]; then
+		echo "Including configuration overrides from $file"
+		cp "$file" /usr/local/apache2/conf/custom
+	fi
+}
+include_conf "/var/www/.docksal/etc/apache/httpd-vhost-overrides.conf"
+include_conf "/var/www/.docksal/etc/apache/httpd-vhosts.conf"
+
 # Run in foreground
 args="-DFOREGROUND"
 

--- a/apache2.4/httpd-foreground
+++ b/apache2.4/httpd-foreground
@@ -9,11 +9,14 @@ echo "Configuring Apache2 environment variables..."
 # Set ServerName of created container
 export APACHE_SERVERNAME="${APACHE_SERVERNAME:-$(cat /etc/hostname)}"
 
+# Run in foreground
+args="-DFOREGROUND"
+
 # Basic HTTP Authentication
 if [[ "$APACHE_BASIC_AUTH_USER" != "" ]] && [[ "$APACHE_BASIC_AUTH_PASS" != "" ]]; then
 	echo "Enabling Basic HTTP Authentication [$APACHE_BASIC_AUTH_USER:$APACHE_BASIC_AUTH_PASS]"
 	htpasswd -cb /usr/local/apache2/htpasswd "$APACHE_BASIC_AUTH_USER" "$APACHE_BASIC_AUTH_PASS"
-	exec httpd -DFOREGROUND -DBasicAuth
-else
-	exec httpd -DFOREGROUND
+	args+=" -DBasicAuth"
 fi
+
+exec httpd ${args}

--- a/tests/config/httpd-vhost-overrides.conf
+++ b/tests/config/httpd-vhost-overrides.conf
@@ -1,0 +1,1 @@
+DirectoryIndex index2.html

--- a/tests/config/httpd-vhosts.conf
+++ b/tests/config/httpd-vhosts.conf
@@ -1,0 +1,6 @@
+<VirtualHost *:80>
+	ServerName docs.test.docksal
+
+	ProxyPass / http://docs.docksal.io/
+	ProxyPassReverse / http://docs.docksal.io/
+</VirtualHost>

--- a/tests/docroot/index.html
+++ b/tests/docroot/index.html
@@ -1,0 +1,1 @@
+index.html

--- a/tests/docroot/index2.html
+++ b/tests/docroot/index2.html
@@ -1,0 +1,1 @@
+index2.html

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+
+# Debugging
+teardown() {
+	echo
+	# TODO: figure out how to deal with this (output from previous run commands showing up along with the error message)
+	echo "Note: ignore the lines between \"...failed\" above and here"
+	echo
+	echo "Status: $status"
+	echo "Output:"
+	echo "================================================================"
+	echo "$output"
+	echo "================================================================"
+}
+
+# Global skip
+# Uncomment below, then comment skip in the test you want to debug. When done, reverse.
+#SKIP=1
+
+@test "Bare server" {
+	[[ $SKIP == 1 ]] && skip
+
+	### Setup ###
+	fin docker rm -vf "$NAME" >/dev/null 2>&1 || true
+	fin docker run --name "$NAME" -d -p 2580:80 -p 25443:443 \
+		"$IMAGE"
+	sleep 2 # TODO: replace with a healthcheck
+
+
+	### Tests ###
+
+	run curl -sSk -I http://test.docksal:2580
+	echo "$output" | grep "HTTP/1.1 200 OK"
+
+	run curl -sSk https://test.docksal:25443
+	echo "$output" | grep "It works!"
+
+	run curl -sSk -I https://test.docksal:25443
+	echo "$output" | grep "HTTP/1.1 200 OK"
+
+	run curl -sSk https://test.docksal:25443
+	echo "$output" | grep "It works!"
+
+	run curl -sSk -I http://test.docksal:2580/nonsense
+	echo "$output" | grep "HTTP/1.1 404 Not Found"
+
+
+	### Cleanup ###
+	fin docker rm -vf "$NAME" >/dev/null 2>&1 || true
+}
+
+@test "Docroot mount" {
+	[[ $SKIP == 1 ]] && skip
+
+	### Setup ###
+	fin docker rm -vf "$NAME" >/dev/null 2>&1 || true
+	fin docker run --name "$NAME" -d -p 2580:80 -p 25443:443 \
+		-v $(pwd)/../tests/docroot:/var/www/docroot \
+		"$IMAGE"
+	sleep 2 # TODO: replace with a healthcheck
+
+
+	### Tests ###
+
+	run curl -sSk -I http://test.docksal:2580
+	echo "$output" | grep "HTTP/1.1 200 OK"
+
+	run curl -sSk http://test.docksal:2580
+	echo "$output" | grep "index.html"
+
+
+	### Cleanup ###
+	fin docker rm -vf "$NAME" >/dev/null 2>&1 || true
+}
+
+@test "Docroot path override" {
+	[[ $SKIP == 1 ]] && skip
+
+	### Setup ###
+	fin docker rm -vf "$NAME" >/dev/null 2>&1 || true
+	fin docker run --name "$NAME" -d -p 2580:80 -p 25443:443 \
+		-v $(pwd)/../tests/docroot:/var/www/html \
+		-e APACHE_DOCUMENTROOT=/var/www/html \
+		"$IMAGE"
+	sleep 2 # TODO: replace with a healthcheck
+
+
+	### Tests ###
+
+	run curl -sSk -I http://test.docksal:2580
+	echo "$output" | grep "HTTP/1.1 200 OK"
+
+	run curl -sSk http://test.docksal:2580
+	echo "$output" | grep "index.html"
+
+
+	### Cleanup ###
+	fin docker rm -vf "$NAME" >/dev/null 2>&1 || true
+}
+
+@test "Basic HTTP Auth" {
+	[[ $SKIP == 1 ]] && skip
+
+	### Setup ###
+	fin docker rm -vf "$NAME" >/dev/null 2>&1 || true
+	fin docker run --name "$NAME" -d -p 2580:80 -p 25443:443 \
+		-v $(pwd)/../tests/docroot:/var/www/docroot \
+		-e APACHE_BASIC_AUTH_USER=user \
+		-e APACHE_BASIC_AUTH_PASS=pass \
+		"$IMAGE" >/dev/null
+	sleep 2 # TODO: replace with a healthcheck
+
+
+	### Tests ###
+
+	# Check authorization is required
+	run curl -sSk -I http://test.docksal:2580
+	# Apache 2.2 returns "HTTP/1.1 401 Authorization Required" while Apache 2.4 returns "HTTP/1.1 401 Unauthorized"
+	if [[ "$NAME" == "docksal-apache-2.2" ]]; then
+		echo "$output" | grep "HTTP/1.1 401 Authorization Required"
+	else
+		echo "$output" | grep "HTTP/1.1 401 Unauthorized"
+	fi
+
+	# Check we can pass authorization
+	run curl -sSk -I -u user:pass http://test.docksal:2580
+	echo "$output" | grep "HTTP/1.1 200 OK"
+
+
+	### Cleanup ###
+	fin docker rm -vf "$NAME" >/dev/null 2>&1 || true
+}
+
+@test "Configuration overrides" {
+	[[ $SKIP == 1 ]] && skip
+
+	### Setup ###
+	fin docker rm -vf "$NAME" >/dev/null 2>&1 || true
+	fin docker run --name "$NAME" -d -p 2580:80 -p 25443:443 \
+		-v $(pwd)/../tests/docroot:/var/www/docroot \
+		-v $(pwd)/../tests/config:/var/www/.docksal/etc/apache \
+		"$IMAGE" >/dev/null
+	sleep 2 # TODO: replace with a healthcheck
+
+
+	### Tests ###
+
+	# Test default virtual host config overrides
+	run curl -sSk -I http://test.docksal:2580
+	echo "$output" | grep "HTTP/1.1 200 OK"
+
+	run curl -sSk http://test.docksal:2580
+	echo "$output" | grep "index2.html"
+
+	# Test extra virtual hosts config
+	run curl -sSk -I http://docs.test.docksal:2580
+	echo "$output" | grep "HTTP/1.1 302"
+
+	run curl -sSk -L http://docs.test.docksal:2580
+	echo "$output"| grep "Docksal Documentation"
+
+
+	### Cleanup ###
+	fin docker rm -vf "$NAME" >/dev/null 2>&1 || true
+}


### PR DESCRIPTION
- Config refactoring
  - DirectoryIndex index.html index.php
  - Inherit log configuration from the stock config
  - Switched to name based virtual hosts
  - Moved SSL config into httpd-vhosts.conf
  - Set SSL cert length to 4096
  - Use a better approach to handling httpd run options on httpd-foreground
- Added support for configuration overrides
- Enabled proxy_httpd_module for Apache 2.4
- Bats tests and automated testing with Travis CI
