### PR TITLE
Release 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - VERSION=apache2.4
 
 install:
-  - curl -fsSL get.docksal.io | sh
+  - curl -fsSL get.docksal.io | bash
   - fin version
   - fin sysinfo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-language: generic
+dist: xenial
 
-services:
-  - docker
+language: minimal
 
 env:
   matrix:

--- a/apache2.2/Dockerfile
+++ b/apache2.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM httpd:2.2-alpine
+FROM httpd:2.2.34-alpine
 
 # Build mod_proxy_fcgi from source
 RUN set -x \

--- a/apache2.2/Dockerfile
+++ b/apache2.2/Dockerfile
@@ -24,7 +24,7 @@ RUN set -x \
 
 # Generate a self-signed cert
 RUN apk add --no-cache openssl \
-	&& openssl req -batch -x509 -newkey rsa:4096 -days 3650 -nodes -sha256 \
+	&& openssl req -batch -x509 -newkey rsa:4096 -days 3650 -nodes -sha256 -subj "/" \
 		-keyout /usr/local/apache2/conf/server.key -out /usr/local/apache2/conf/server.crt \
 	&& apk del openssl
 
@@ -50,9 +50,13 @@ RUN set -x \
 
 COPY httpd-foreground /usr/local/bin/
 COPY conf /usr/local/apache2/conf
+COPY healthcheck.sh /opt/healthcheck.sh
 
 WORKDIR /var/www
 
 EXPOSE 80 443
 
 CMD ["httpd-foreground"]
+
+# Health check script
+HEALTHCHECK --interval=5s --timeout=1s --retries=12 CMD ["/opt/healthcheck.sh"]

--- a/apache2.2/healthcheck.sh
+++ b/apache2.2/healthcheck.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+[[ ! -f ${HTTPD_PREFIX}/logs/httpd.pid ]] && exit 1
+
+exit 0

--- a/apache2.4/Dockerfile
+++ b/apache2.4/Dockerfile
@@ -2,7 +2,7 @@ FROM httpd:2.4-alpine
 
 # Generate a self-signed cert
 RUN apk add --no-cache openssl \
-	&& openssl req -batch -x509 -newkey rsa:4096 -days 3650 -nodes -sha256 \
+	&& openssl req -batch -x509 -newkey rsa:4096 -days 3650 -nodes -sha256 -subj "/" \
 		-keyout /usr/local/apache2/conf/server.key -out /usr/local/apache2/conf/server.crt \
 	&& apk del openssl
 
@@ -30,9 +30,13 @@ RUN set -x \
 
 COPY httpd-foreground /usr/local/bin/
 COPY conf /usr/local/apache2/conf
+COPY healthcheck.sh /opt/healthcheck.sh
 
 WORKDIR /var/www
 
 EXPOSE 80 443
 
 CMD ["httpd-foreground"]
+
+# Health check script
+HEALTHCHECK --interval=5s --timeout=1s --retries=12 CMD ["/opt/healthcheck.sh"]

--- a/apache2.4/Dockerfile
+++ b/apache2.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM httpd:2.4-alpine
+FROM httpd:2.4.35-alpine
 
 # Generate a self-signed cert
 RUN apk add --no-cache openssl \

--- a/apache2.4/healthcheck.sh
+++ b/apache2.4/healthcheck.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+[[ ! -f ${HTTPD_PREFIX}/logs/httpd.pid ]] && exit 1
+
+exit 0

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -196,7 +196,7 @@ _healthcheck_wait ()
 
 	# Test extra virtual hosts config
 	run curl -sSk -I http://docs.test.docksal:2580
-	echo "$output" | grep "HTTP/1.1 302"
+	echo "$output" | grep "HTTP/1.1 301"
 
 	run curl -sSk -L http://docs.test.docksal:2580
 	echo "$output"| grep "Docksal Documentation"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -33,31 +33,27 @@ _healthcheck ()
 }
 
 # Waits for containers to become healthy
-# For reasoning why we are not using  `depends_on` `condition` see here:
-# https://github.com/docksal/docksal/issues/225#issuecomment-306604063
 _healthcheck_wait ()
 {
-    # Wait for cli to become ready by watching its health status
-    local container_name="${NAME}"
-    local delay=5
-    local timeout=30
-    local elapsed=0
+	# Wait for cli to become ready by watching its health status
+	local container_name="${NAME}"
+	local delay=5
+	local timeout=30
+	local elapsed=0
 
-    until _healthcheck "$container_name"; do
-	echo "Waiting for $container_name to become ready..."
-	sleep "$delay";
+	until _healthcheck "$container_name"; do
+		echo "Waiting for $container_name to become ready..."
+		sleep "$delay";
 
-	# Give the container 30s to become ready
-	elapsed=$((elapsed + delay))
-	if ((elapsed > timeout)); then
-	    echo-error "$container_name heathcheck failed" \
-		"Container did not enter a healthy state within the expected amount of time." \
-		"Try ${yellow}fin restart${NC}"
-	    exit 1
-	fi
-    done
+		# Give the container 30s to become ready
+		elapsed=$((elapsed + delay))
+		if ((elapsed > timeout)); then
+			echo "$container_name heathcheck failed"
+			exit 1
+		fi
+	done
 
-    return 0
+	return 0
 }
 
 # Global skip


### PR DESCRIPTION
- Added healthcheck support
- Pinned upstream versions:
  - Apache 2.2.34 (last 2.2 version, EOL as of 2018-01-01, deprecated and will be dropped in next release)
  - Apache 2.4.35 (fix mod_ssl issue)
- Switched Travis builds to Ubuntu 18.04 (xenial) minimal flavor
- Updated tests
